### PR TITLE
OLMIS-7660: Add tooltip react component

### DIFF
--- a/src/react-components/modals/tooltip.jsx
+++ b/src/react-components/modals/tooltip.jsx
@@ -1,0 +1,30 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+import React from 'react';
+
+const Tooltip = ({ displayText, ...props }) => {
+
+    return (
+        <div className='popover bottom fade in' {...props}>
+            <div className='arrow'/>
+            <div className='popover-content'>
+                {displayText}
+            </div>
+        </div>
+    );
+};
+
+export default Tooltip;


### PR DESCRIPTION
Added tooltip. The one at the bottom is plain component and the gray one is after styling (for soh page)
![image](https://user-images.githubusercontent.com/110475297/222720283-165c6e0f-eed7-4f9a-9300-d10c45e97a9c.png)
