### PR TITLE
OLMIS-8027: Changed modal prop to prevent inconsistency around the app

### DIFF
--- a/src/react-components/DetailsBlock.jsx
+++ b/src/react-components/DetailsBlock.jsx
@@ -21,8 +21,8 @@ const DetailsBlock = ({ data, className }) => {
         <div className={`details-block-container ${className ? className : ''}`}>
             <table>
                 <tbody>
-                    {data.map((elements) => (
-                        <tr key={elements}>
+                    {data.map((elements, index) => (
+                        <tr key={index}>
                             {elements.map((element) => (
                                 <td key={element.topic} className='element'>
                                     {element.topic}: <b>{element.value}</b>

--- a/src/react-components/modals/Modal.jsx
+++ b/src/react-components/modals/Modal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-const Modal = ({ isOpen, body, alertModal = false, sourceOfFundStyle = '' }) => {
+const Modal = ({ isOpen, children, alertModal = false, sourceOfFundStyle = '' }) => {
     const showHideClassName = isOpen ? 'react-modal display-block' : 'react-modal display-none';
     const alertModalClassName = alertModal ? 'alert-modal is-error' : '';
 
@@ -23,7 +23,7 @@ const Modal = ({ isOpen, body, alertModal = false, sourceOfFundStyle = '' }) => 
                 (
                     <div className={`${showHideClassName} ${alertModalClassName}`}>
                         <section className={`modal-main ${sourceOfFundStyle ? 'source-of-fund-modal' : ''}`}>
-                            {body}
+                            {children}
                         </section>
                     </div>
                 )


### PR DESCRIPTION
For purposes of ticket: https://openlmis.atlassian.net/browse/OLMIS-7987. Modal prop children was changed to 'body' which caused inconsistency in the prop passing. And some modals which were using the old prop name were not displaying any content. Which caused the issue mentioned in ticket: https://openlmis.atlassian.net/browse/OLMIS-8027

Changed prop name back to 'children', because only one spot uses the 'body' name