### PR TITLE
OLMIS-8082: Added option to handle translations in React Select and MultiSelect

### DIFF
--- a/src/react-components/inputs/messages_en.json
+++ b/src/react-components/inputs/messages_en.json
@@ -1,0 +1,3 @@
+{
+    "react.select.defaultMessage": "Select an option"
+}

--- a/src/react-components/inputs/multi-select.jsx
+++ b/src/react-components/inputs/multi-select.jsx
@@ -13,7 +13,8 @@
  * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
  */
 
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
+import getService from '../utils/angular-utils';
 
 function useOutsideAlerter(ref, setIsOptionListShown) {
   useEffect(() => {
@@ -28,47 +29,47 @@ function useOutsideAlerter(ref, setIsOptionListShown) {
     };
   }, [ref]);
 }
-  
-const MultiSelect = ({ options, selected, toggleOption, disabled }) => {
-    const SELECT_OPTION_LABEL = "Select an option";
-    
-    const [isOptionListShown, setIsOptionListShown] = useState(false);
 
-    const handleClickMultiSelect = () => {
-      setIsOptionListShown(current => !current);
-    };
+const MultiSelect = ({ options, selected, toggleOption, disabled, isTranslatable = false }) => {
 
-    const wrapperRef = useRef(null);
-    useOutsideAlerter(wrapperRef, setIsOptionListShown);
+  const [isOptionListShown, setIsOptionListShown] = useState(false);
+  const { formatMessage } = useMemo(() => getService('messageService'), []);
+  const SELECT_OPTION_LABEL = formatMessage('react.select.defaultMessage');
+  const handleClickMultiSelect = () => {
+    setIsOptionListShown(current => !current);
+  };
 
-    return (
+  const wrapperRef = useRef(null);
+  useOutsideAlerter(wrapperRef, setIsOptionListShown);
+
+  return (
+    <div
+      ref={wrapperRef}
+      onClick={handleClickMultiSelect}
+      className="multiselect"
+      style={disabled ? { pointerEvents: "none", opacity: "0.4" } : {}}
+    >
+      <div className="multiselect-selected">
+        <i className="fa fa-sort-desc" aria-hidden="true"></i>
         <div
-          ref={wrapperRef}
-          onClick={handleClickMultiSelect} 
-          className="multiselect" 
-          style={disabled ? {pointerEvents: "none", opacity: "0.4"} : {}}
+          style={{ marginLeft: "5px" }}
         >
-            <div className="multiselect-selected">
-                <i className="fa fa-sort-desc" aria-hidden="true"></i>
-                <div 
-                  style={{marginLeft: "5px"}}
-                > 
-                  {selected.length > 0 ? selected.join(', ') : SELECT_OPTION_LABEL} 
-                </div>
-            </div>
-            {isOptionListShown && <ul className="multiselect-options">
-                {options.map(option => {
-                    const isSelected = selected.includes(option.id);
-                    return (
-                        <li className="multiselect-option" onClick={() => toggleOption({ id: option.id })}>
-                            <input type="checkbox" checked={isSelected} className="multiselect-option-checkbox"></input>
-                            <span>{option.name}</span>
-                        </li>
-                    );
-                })}
-            </ul>}
+          {selected.length > 0 ? selected.join(', ') : SELECT_OPTION_LABEL}
         </div>
-    );
+      </div>
+      {isOptionListShown && <ul className="multiselect-options">
+        {options.map(option => {
+          const isSelected = selected.includes(option.id);
+          return (
+            <li className="multiselect-option" onClick={() => toggleOption({ id: option.id })}>
+              <input type="checkbox" checked={isSelected} className="multiselect-option-checkbox"></input>
+              <span>{ isTranslatable ? formatMessage(option.name) : option.name }</span>
+            </li>
+          );
+        })}
+      </ul>}
+    </div>
+  );
 };
 
 export default MultiSelect;

--- a/src/react-components/inputs/select.jsx
+++ b/src/react-components/inputs/select.jsx
@@ -13,11 +13,12 @@
  * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
+import getService from '../utils/angular-utils';
 
-const Select = ({ options = [], value, onChange, objectKey, defaultOption, ...props }) => {
-
+const Select = ({ options = [], value, onChange, objectKey, defaultOption='react.select.defaultMessage', isTranslatable = false, ...props }) => {
     const findOption = (val) => _.find(options, (opt) => (_.get(opt.value, objectKey) === val));
+    const { formatMessage } = useMemo(() => getService('messageService'), []);
 
     const handleChange = (event) => {
         const { value } = event.target;
@@ -40,9 +41,11 @@ const Select = ({ options = [], value, onChange, objectKey, defaultOption, ...pr
         selectValue = !value ? value : _.get(value, objectKey);
     }
 
+    const getOptionValue = (option) => isTranslatable ? formatMessage(option) : option;
+
     return (
         <select value={selectValue} onChange={handleChange} {...props}>
-            <option value="">{defaultOption || 'Select an option'}</option>
+            <option value="">{formatMessage(defaultOption)}</option>
             {
                 options.map(
                     ({value, name}) => {
@@ -52,7 +55,7 @@ const Select = ({ options = [], value, onChange, objectKey, defaultOption, ...pr
                             optionValue = _.get(value, objectKey);
                         }
 
-                        return (<option key={optionValue} value={optionValue}>{name}</option>);
+                        return (<option key={optionValue} value={optionValue}>{getOptionValue(name)}</option>);
                     }
                 )
             }


### PR DESCRIPTION
In React Select and MultiSelect it was only possible to enter plain text options. Here is extension allowing to add translation keys here

resolving ticket: https://openlmis.atlassian.net/browse/OLMIS-8082
