### PR TITLE
OLMIS-8067: allow to clear the storage and keep lang

### DIFF
--- a/src/openlmis-local-storage/local-storage.service.js
+++ b/src/openlmis-local-storage/local-storage.service.js
@@ -218,12 +218,21 @@ angularLocalStorage.service('localStorageService', [
             }
         };
 
+        // Removes all the user's data from the local storage except the current locale
+        function clearTheUserDataStorage() {
+            var currentLocale = localStorage.getItem('openlmis.current_locale');
+
+            localStorage.clear();
+            localStorage.setItem('openlmis.current_locale', currentLocale);
+        }
+
         return {
             isSupported: browserSupportsLocalStorage,
             add: addToLocalStorage,
             get: getFromLocalStorage,
             remove: removeFromLocalStorage,
             clearAll: clearAllFromLocalStorage,
+            clearTheUserDataStorage: clearTheUserDataStorage,
             cookie: {
                 add: addToCookies,
                 get: getFromCookies,


### PR DESCRIPTION
[OLMIS-8067](https://openlmis.atlassian.net/browse/OLMIS-8067)

[LINKED PR](https://github.com/OpenLMIS/openlmis-auth-ui/pull/19)

Changes:
- Add a `clearTheUserDataStorage` function to clear local storage while preserving the user's language preference.





[OLMIS-8067]: https://openlmis.atlassian.net/browse/OLMIS-8067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ