### PR TITLE
OE-111: create a quantity input/toggle with react

### DIFF
--- a/src/openlmis-quantity-unit-input/openlmis-quantity-unit-input.jsx
+++ b/src/openlmis-quantity-unit-input/openlmis-quantity-unit-input.jsx
@@ -1,0 +1,165 @@
+import _ from 'lodash';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import InputCell from '../react-components/table/input-cell';
+import getService from '../react-components/utils/angular-utils';
+
+const DEBOUNCE_DELAY = 300;
+
+export default function QuantityUnitInput({
+  showInDoses,
+  item,
+  onChangeQuantity,
+  ...inputCellProps
+}) {
+  const messageService = useMemo(() => getService('messageService'), []);
+  const quantityUnitCalculateService = useMemo(
+    () => getService('quantityUnitCalculateService'),
+    []
+  );
+
+  const [localValues, setLocalValues] = useState({
+    orderedQuantity: item?.orderedQuantity || '',
+    quantityInPacks: item?.quantityInPacks || '',
+    quantityRemainderInDoses: item?.quantityRemainderInDoses || '',
+  });
+
+  const netContent = useMemo(
+    () => item?.orderable?.netContent || 1,
+    [item?.orderable?.netContent]
+  );
+
+  const isQuantityRemainderInDosesDisabled = useCallback(() => {
+    return netContent === 1;
+  }, [netContent]);
+
+  // Sync local state when item props change
+  useEffect(() => {
+    setLocalValues({
+      orderedQuantity: item?.orderedQuantity || '',
+      quantityInPacks: item?.quantityInPacks || '',
+      quantityRemainderInDoses: item?.quantityRemainderInDoses || '',
+    });
+  }, [
+    item?.orderedQuantity,
+    item?.quantityInPacks,
+    item?.quantityRemainderInDoses,
+  ]);
+
+  const debouncedOnChangeQuantity = useMemo(
+    () =>
+      _.debounce((recalculatedItem) => {
+        onChangeQuantity(recalculatedItem);
+      }, DEBOUNCE_DELAY),
+    [onChangeQuantity]
+  );
+
+  // Cleanup debounced function on unmount
+  useEffect(() => {
+    return () => {
+      debouncedOnChangeQuantity.cancel();
+    };
+  }, [debouncedOnChangeQuantity]);
+
+  const handleChangeValue = useCallback(
+    (field, value) => {
+      setLocalValues((prev) => ({ ...prev, [field]: value }));
+
+      const numericValue =
+        value === '' || value === undefined ? undefined : Number(value);
+
+      const updatedItem = { ...item, [field]: numericValue };
+
+      const recalculatedItem =
+        quantityUnitCalculateService.recalculateInputQuantity(
+          updatedItem,
+          netContent,
+          showInDoses,
+          'orderedQuantity'
+        );
+
+      debouncedOnChangeQuantity(recalculatedItem);
+    },
+    [
+      item,
+      netContent,
+      showInDoses,
+      quantityUnitCalculateService,
+      debouncedOnChangeQuantity,
+    ]
+  );
+
+  const formatMessage = useCallback(
+    (key) => {
+      return messageService.get(key);
+    },
+    [messageService]
+  );
+
+  useEffect(() => {
+    // Recalculate the item if it has orderedQuantity but no quantityRemainderInDoses or quantityInPacks
+    // and if we are not showing in doses
+    if (
+      !showInDoses &&
+      item?.orderedQuantity &&
+      !item?.quantityRemainderInDoses &&
+      !item?.quantityInPacks
+    ) {
+      const recalculatedItem =
+        quantityUnitCalculateService.recalculateInputQuantity(
+          item,
+          netContent,
+          !showInDoses,
+          'orderedQuantity'
+        );
+
+      onChangeQuantity(recalculatedItem);
+    }
+  }, [
+    item,
+    netContent,
+    showInDoses,
+    onChangeQuantity,
+    quantityUnitCalculateService,
+  ]);
+
+  if (showInDoses) {
+    return (
+      <div>
+        <InputCell
+          {...inputCellProps}
+          value={localValues.orderedQuantity}
+          onChange={(value) => handleChangeValue('orderedQuantity', value)}
+          key={`orderedQuantity-${item?.orderable?.id}`}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className='openlmis-input'>
+      <InputCell
+        {...inputCellProps}
+        value={localValues.quantityInPacks}
+        onChange={(value) => handleChangeValue('quantityInPacks', value)}
+        placeholder={formatMessage('openlmisInputDosesPacks.Packs')}
+        id='quantityInPacks'
+        key={`quantityInPacks-${item?.orderable?.id}`}
+      />
+      <p> ( + </p>
+      <InputCell
+        {...inputCellProps}
+        value={localValues.quantityRemainderInDoses}
+        onChange={(value) =>
+          handleChangeValue('quantityRemainderInDoses', value)
+        }
+        disabled={
+          inputCellProps.disabled || isQuantityRemainderInDosesDisabled()
+        }
+        placeholder={formatMessage('openlmisInputDosesPacks.Doses')}
+        id='quantityRemainderInDoses'
+        key={`quantityRemainderInDoses-${item?.orderable?.id}`}
+      />
+      <p>{formatMessage('openlmisInputDosesPacks.DosesBracket')}</p>
+    </div>
+  );
+}

--- a/src/openlmis-quantity-unit-toggle/default-quantity-unit.flag.constant.js
+++ b/src/openlmis-quantity-unit-toggle/default-quantity-unit.flag.constant.js
@@ -1,0 +1,30 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc object
+     * @name openlmis-quantity-unit-toggle.constant:DEFAULT_QUANTITY_UNIT_FEATURE_FLAG
+     * 
+     * @description
+     * This is a constant that defines the feature flag for the default quantity unit.
+     */
+    angular
+        .module('openlmis-quantity-unit-toggle')
+        .constant('DEFAULT_QUANTITY_UNIT_FEATURE_FLAG', 'DEFAULT_QUANTITY_UNIT');
+})();

--- a/src/openlmis-quantity-unit-toggle/default-quantity-unit.flag.run.js
+++ b/src/openlmis-quantity-unit-toggle/default-quantity-unit.flag.run.js
@@ -1,0 +1,37 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    angular
+        .module('openlmis-quantity-unit-toggle')
+        .run(setDefaultQuantityUnit);
+
+    setDefaultQuantityUnit.$inject = ['featureFlagService', 'DEFAULT_QUANTITY_UNIT_FEATURE_FLAG', 'QUANTITY_UNIT'];
+
+    /**
+     * @ngdoc function
+     * @name openlmis-quantity-unit-toggle.run:setDefaultQuantityUnit
+     * 
+     * @description
+     * This function sets the feature flag for the default quantity unit.
+     * It initializes the feature flag with a default value of 'DOSES'.
+     */
+    function setDefaultQuantityUnit(featureFlagService, DEFAULT_QUANTITY_UNIT_FEATURE_FLAG, QUANTITY_UNIT) {
+        featureFlagService.set(DEFAULT_QUANTITY_UNIT_FEATURE_FLAG, '${DEFAULT_QUANTITY_UNIT}', QUANTITY_UNIT.DOSES);
+    }
+})();

--- a/src/openlmis-quantity-unit-toggle/quantity-unit-option.flag.constant.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit-option.flag.constant.js
@@ -1,0 +1,30 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc object
+     * @name openlmis-quantity-unit-toggle.constant:QUANTITY_UNIT_OPTION_FEATURE_FLAG
+     * 
+     * @description
+     * This is a constant that defines the feature flag for the quantity unit option toggle.
+     */
+    angular
+        .module('openlmis-quantity-unit-toggle')
+        .constant('QUANTITY_UNIT_OPTION_FEATURE_FLAG', 'QUANTITY_UNIT_OPTION');
+})();

--- a/src/openlmis-quantity-unit-toggle/quantity-unit-option.flag.run.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit-option.flag.run.js
@@ -1,0 +1,36 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    angular
+        .module('openlmis-quantity-unit-toggle')
+        .run(setDefaultQuantityUnit);
+
+    setDefaultQuantityUnit.$inject = ['featureFlagService', 'QUANTITY_UNIT_OPTION_FEATURE_FLAG', 'QUANTITY_UNIT'];
+
+    /**
+     * @ngdoc function
+     * @name openlmis-quantity-unit-toggle.run:setDefaultQuantityUnit
+     * 
+     * @description
+     * This function sets the feature flag for the quantity unit option to the default value.
+     */
+    function setDefaultQuantityUnit(featureFlagService, QUANTITY_UNIT_OPTION_FEATURE_FLAG, QUANTITY_UNIT) {
+        featureFlagService.set(QUANTITY_UNIT_OPTION_FEATURE_FLAG, '${QUANTITY_UNIT_OPTION}', QUANTITY_UNIT.BOTH);
+    }
+})();

--- a/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.controller.spec.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.controller.spec.js
@@ -18,7 +18,12 @@ describe('QuantityUnitToggleController', function() {
     var vm, $controller, messageService, QUANTITY_UNIT, localStorageService;
 
     beforeEach(function() {
-        module('openlmis-quantity-unit-toggle');
+        module('openlmis-quantity-unit-toggle', function($provide) {
+            $provide.value('featureFlagService', {
+                set: function() {},
+                get: function() {}
+            });
+        });
 
         inject(function($injector) {
             $controller = $injector.get('$controller');

--- a/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.jsx
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.jsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useMemo } from 'react';
+import getService from '../react-components/utils/angular-utils';
+
+export default function QuantityUnitToggle({ selectedUnit, onUnitChange }) {
+  const { formatMessage } = useMemo(() => getService('messageService'), []);
+  const QUANTITY_UNIT = useMemo(() => getService('QUANTITY_UNIT'), []);
+  const featureFlagService = useMemo(
+    () => getService('featureFlagService'),
+    []
+  );
+  const QUANTITY_UNIT_OPTION_FEATURE_FLAG = useMemo(
+    () => getService('QUANTITY_UNIT_OPTION_FEATURE_FLAG'),
+    []
+  );
+  const quantityUnits = useMemo(
+    () => [QUANTITY_UNIT.PACKS, QUANTITY_UNIT.DOSES],
+    [QUANTITY_UNIT]
+  );
+
+  const isVisible = useMemo(() => {
+    if (featureFlagService && QUANTITY_UNIT_OPTION_FEATURE_FLAG) {
+      const quantityUnitOption = featureFlagService.get(
+        QUANTITY_UNIT_OPTION_FEATURE_FLAG
+      );
+      return quantityUnitOption === QUANTITY_UNIT.BOTH;
+    }
+
+    return false;
+  }, [
+    featureFlagService,
+    QUANTITY_UNIT_OPTION_FEATURE_FLAG,
+    QUANTITY_UNIT.BOTH,
+  ]);
+
+  const handleQuantityUnitChange = useCallback(
+    (event) => {
+      const newQuantityUnit = event.target.value;
+      if (onUnitChange) {
+        onUnitChange(newQuantityUnit);
+      }
+    },
+    [onUnitChange]
+  );
+
+  const getQuantityUnitMessage = useCallback(
+    (unit) => {
+      return formatMessage(QUANTITY_UNIT.$getDisplayName(unit));
+    },
+    [formatMessage, QUANTITY_UNIT]
+  );
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className='button-toggle'>
+      {quantityUnits.map((unit) => (
+        <label key={unit} className={selectedUnit === unit ? 'selected' : ''}>
+          <input
+            type='radio'
+            name='quantity-unit'
+            value={unit}
+            checked={selectedUnit === unit}
+            onChange={handleQuantityUnitChange}
+          />
+          {getQuantityUnitMessage(unit)}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/openlmis-quantity-unit-toggle/quantity-unit.service.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit.service.js
@@ -85,17 +85,20 @@
          * 
          * @return {item}                  number of doses
          */
-        function recalculateInputQuantity(item, netContent, inDoses) {
+        function recalculateInputQuantity(item, netContent, inDoses, quantityKey) {
+            var usedQuantityKey = quantityKey || 'quantity';
+
             if (isNetContentUndefinedOrZero(netContent)) {
                 return 0;
             } else if (inDoses) {
-                item.quantityInPacks = Math.floor(item.quantity / netContent);
-                item.quantityRemainderInDoses = item.quantity % netContent;
+                item.quantityInPacks = Math.floor(item[usedQuantityKey] / netContent);
+                item.quantityRemainderInDoses = item[usedQuantityKey] % netContent;
             } else {
-                item.quantity = getTotalQuantityInDoses(
+                item[usedQuantityKey] = getTotalQuantityInDoses(
                     item.quantityInPacks, item.quantityRemainderInDoses, netContent
                 );
             }
+
             return item;
         }
 
@@ -115,10 +118,19 @@
          */
         function getTotalQuantityInDoses(quantityInPacks, quantityRemainderInDoses, netContent) {
             var quantityInDoses = 0;
-            if (quantityInPacks !== undefined) {
+
+            if (quantityInPacks !== undefined && quantityInPacks !== null && !isNaN(quantityInPacks)) {
                 quantityInDoses = quantityInPacks * netContent;
             }
-            quantityInDoses += quantityRemainderInDoses;
+
+            if (
+                quantityRemainderInDoses !== undefined &&
+                quantityRemainderInDoses !== null &&
+                !isNaN(quantityRemainderInDoses)
+            ) {
+                quantityInDoses += quantityRemainderInDoses;
+            }
+
             return quantityInDoses;
         }
 


### PR DESCRIPTION
[OE-111](https://openlmis.atlassian.net/browse/OE-111)

Changes:
- Create new React components for the quantity input and unit toggle, mirroring the functionality and appearance of their existing Angular counterparts.

[OE-111]: https://openlmis.atlassian.net/browse/OE-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ