### PR TITLE
OLMIS-8192: Enable text input auto-resize in tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Upcoming Version (WIP)
 
 Improvements:
 * [SELV3-748](https://openlmis.atlassian.net/browse/SELV3-748) Resolved cookie issue causing untranslated warning messages
+* [OLMIS-8192](https://openlmis.atlassian.net/browse/OLMIS-8192): Editable text inputs inside table cells now grow with their content.
 
 Bug fixes:
 * [OLMIS-8165](https://openlmis.atlassian.net/browse/OLMIS-8165): Fix modals (React) by enabling vertical scrolling when their content exceeds the max height.

--- a/src/ui-components-vendors.js
+++ b/src/ui-components-vendors.js
@@ -25,6 +25,9 @@ window.moment = require('moment-timezone');
 window.shortid = require('js-shortid');
 
 //eslint-disable-next-line no-undef
+window.autosizeInput = require('@bower_components/autosize-input');
+
+//eslint-disable-next-line no-undef
 window.PouchDB = require('pouchdb').default;
 //eslint-disable-next-line no-undef
 window.PouchDB.plugin(require('pouchdb-find').default);


### PR DESCRIPTION
Editable text inputs inside table cells now grow with their content as the user types. Required by the matching requisition-ui change.