### PR TITLE
OLMIS-8220: Add z-index variable for sticky header

### DIFF
--- a/src/common/_variables.scss
+++ b/src/common/_variables.scss
@@ -80,3 +80,6 @@ $res-xxl: 1400px;
 
 $sidebar-width: 16em !default;
 $popover-width: 20em;
+
+// Z-index
+$z-index-header-sticky: 1030 !default; // above content, below modals


### PR DESCRIPTION
New shared variable controls header layer so it sits above content but below modals.