### PR TITLE
OLMIS-8043: Close offline modal on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Improvements:
 
 Bug fixes:
 * [OLMIS-8165](https://openlmis.atlassian.net/browse/OLMIS-8165): Fix modals (React) by enabling vertical scrolling when their content exceeds the max height.
+* [OLMIS-8043](https://openlmis.atlassian.net/browse/OLMIS-8043): Add alertService method to close the currently displayed alert modal.
 
 
 7.2.15 / 2026-02-05

--- a/src/openlmis-modal/alert.service.js
+++ b/src/openlmis-modal/alert.service.js
@@ -40,6 +40,7 @@
         this.success = success;
         this.info = info;
         this.offline = offline;
+        this.close = close;
 
         /**
          * @ngdoc method
@@ -129,6 +130,20 @@
                 message: message,
                 buttonLabel: buttonLabel
             });
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-modal.alertService
+         * @name close
+         *
+         * @description
+         * Closes the currently displayed alert modal, if any.
+         */
+        function close() {
+            if (modal) {
+                modal.hide();
+            }
         }
 
         function showAlert(config) {

--- a/src/openlmis-modal/alert.service.spec.js
+++ b/src/openlmis-modal/alert.service.spec.js
@@ -28,7 +28,8 @@ describe('alertService', function() {
         this.modalDeferred = this.$q.defer();
 
         this.modalMock = {
-            promise: this.modalDeferred.promise
+            promise: this.modalDeferred.promise,
+            hide: jasmine.createSpy('hide')
         };
 
         spyOn(this.openlmisModalService, 'createDialog').andReturn(this.modalMock);
@@ -323,6 +324,36 @@ describe('alertService', function() {
                 expect(rejected).toBeUndefined();
             });
 
+        });
+
+    });
+
+    describe('close', function() {
+
+        it('should hide the current modal if one is open', function() {
+            this.alertService.error('Error Title', 'Error Message');
+
+            this.alertService.close();
+
+            expect(this.modalMock.hide).toHaveBeenCalled();
+        });
+
+        it('should be a no-op when no modal is open', function() {
+            expect(function() {
+                this.alertService.close();
+            }.bind(this)).not.toThrow();
+
+            expect(this.modalMock.hide).not.toHaveBeenCalled();
+        });
+
+        it('should be a no-op after the modal has been closed', function() {
+            this.alertService.error('Error Title', 'Error Message');
+            this.modalDeferred.resolve();
+            this.$rootScope.$apply();
+
+            this.alertService.close();
+
+            expect(this.modalMock.hide).not.toHaveBeenCalled();
         });
 
     });


### PR DESCRIPTION
The offline navigation modal now closes automatically when the connection is restored.