### PR TITLE
OLMIS-8191: Grow table cell text fields with content

### DIFF
--- a/src/openlmis-table-form/_table-forms.scss
+++ b/src/openlmis-table-form/_table-forms.scss
@@ -141,3 +141,12 @@ td > label.checkbox {
   min-width: 2em;
   width: 100%;
 }
+
+.openlmis-table td > div.input-control > textarea {
+  min-width: 14em;
+  max-width: 20em;
+  white-space: pre-wrap;
+  overflow: hidden;
+  resize: none;
+  vertical-align: middle;
+}

--- a/src/openlmis-table-form/textarea-auto-resize.directive.js
+++ b/src/openlmis-table-form/textarea-auto-resize.directive.js
@@ -1,0 +1,103 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc directive
+     * @restrict E
+     * @name openlmis-table-form.directive:textareaAutoResize
+     *
+     * @description
+     * Adds auto-resize to textarea elements inside table cells. The textarea grows
+     * horizontally with its content up to the column max-width (set in CSS); once the
+     * content reaches that width it wraps and the textarea grows vertically instead.
+     *
+     * @example
+     * ```
+     * <textarea ng-model="model"></textarea>
+     * ```
+     */
+    var GHOST_ID = 'openlmisTextareaAutoResizeGhost';
+    var GHOST_STYLE = 'display:inline-block;position:absolute;top:0;left:-9999px;' +
+        'visibility:hidden;height:0;overflow:hidden;white-space:pre;';
+    var MEASURED_PROPERTIES = [
+        'fontFamily', 'fontSize', 'fontWeight', 'fontStyle', 'letterSpacing',
+        'paddingLeft', 'paddingRight', 'borderLeftWidth', 'borderRightWidth', 'boxSizing'
+    ];
+
+    angular
+        .module('openlmis-table-form')
+        .directive('textarea', textareaAutoResize);
+
+    function textareaAutoResize() {
+        var directive = {
+            link: link,
+            restrict: 'E'
+        };
+        return directive;
+
+        function link(scope, element) {
+            if (shouldSkipElement(element)) {
+                return;
+            }
+
+            var el = element[0];
+            scope.$watch(function() {
+                return el.value;
+            }, function() {
+                el.style.width = measureContentWidth(el) + 'px';
+                el.style.height = 'auto';
+                el.style.height = el.scrollHeight + 'px';
+            });
+        }
+
+        function measureContentWidth(el) {
+            var ghost = getGhost();
+            var style = window.getComputedStyle(el);
+
+            MEASURED_PROPERTIES.forEach(function(property) {
+                ghost.style[property] = style[property];
+            });
+            ghost.textContent = el.value || el.getAttribute('placeholder') || '';
+
+            return ghost.offsetWidth;
+        }
+
+        function getGhost() {
+            var ghost = document.getElementById(GHOST_ID);
+            if (!ghost) {
+                ghost = document.createElement('div');
+                ghost.id = GHOST_ID;
+                ghost.style.cssText = GHOST_STYLE;
+                document.body.appendChild(ghost);
+            }
+            return ghost;
+        }
+
+        function shouldSkipElement(element) {
+            return element.parents().length < 2 || isOutsideTd(element);
+        }
+
+        function isOutsideTd(element) {
+            var parents = element.parents();
+
+            return parents[1].localName !== 'td' || parents[0].localName !== 'div' ||
+                !parents[0].classList.contains('input-control');
+        }
+    }
+
+})();

--- a/src/openlmis-table-form/textarea-auto-resize.directive.spec.js
+++ b/src/openlmis-table-form/textarea-auto-resize.directive.spec.js
@@ -24,7 +24,7 @@ describe('Textarea automatic resize directive', function() {
         });
 
         this.compileMarkup = function(markup) {
-            var element = this.$compile(markup)(this.$scope);
+            const element = this.$compile(markup)(this.$scope);
             angular.element('body').append(element);
             this.$scope.$apply();
             return element;
@@ -32,7 +32,7 @@ describe('Textarea automatic resize directive', function() {
 
         this.$scope = this.$rootScope.$new();
 
-        var markup =
+        const markup =
             '<table><tr><td>' +
                 '<textarea>short</textarea>' +
             '</td></tr></table>';
@@ -42,36 +42,36 @@ describe('Textarea automatic resize directive', function() {
     });
 
     it('should set an explicit width and height when textarea has a value', function() {
-        expect(parseInt(this.textarea[0].style.width, 10)).toBeGreaterThan(0);
-        expect(parseInt(this.textarea[0].style.height, 10)).toBeGreaterThan(0);
+        expect(Number.parseInt(this.textarea[0].style.width, 10)).toBeGreaterThan(0);
+        expect(Number.parseInt(this.textarea[0].style.height, 10)).toBeGreaterThan(0);
     });
 
     it('should grow width when value becomes longer', function() {
-        var previousWidth = parseInt(this.textarea[0].style.width, 10);
+        const previousWidth = Number.parseInt(this.textarea[0].style.width, 10);
 
         this.textarea[0].value = 'a value that is clearly longer than the initial one';
         this.$scope.$apply();
 
-        expect(parseInt(this.textarea[0].style.width, 10)).toBeGreaterThan(previousWidth);
+        expect(Number.parseInt(this.textarea[0].style.width, 10)).toBeGreaterThan(previousWidth);
     });
 
     it('should grow height when value spans multiple lines', function() {
-        var previousHeight = parseInt(this.textarea[0].style.height, 10);
+        const previousHeight = Number.parseInt(this.textarea[0].style.height, 10);
 
         this.textarea[0].value = 'first line\nsecond line\nthird line\nfourth line';
         this.$scope.$apply();
 
-        expect(parseInt(this.textarea[0].style.height, 10)).toBeGreaterThan(previousHeight);
+        expect(Number.parseInt(this.textarea[0].style.height, 10)).toBeGreaterThan(previousHeight);
     });
 
     it('should do nothing for a textarea outside of a table cell', function() {
-        var markup =
+        const markup =
             '<form>' +
                 '<textarea>outside</textarea>' +
             '</form>';
 
-        var element = this.compileMarkup(markup);
-        var textarea = element.find('textarea');
+        const element = this.compileMarkup(markup);
+        const textarea = element.find('textarea');
 
         expect(textarea[0].style.width).toEqual('');
         expect(textarea[0].style.height).toEqual('');

--- a/src/openlmis-table-form/textarea-auto-resize.directive.spec.js
+++ b/src/openlmis-table-form/textarea-auto-resize.directive.spec.js
@@ -1,0 +1,79 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('Textarea automatic resize directive', function() {
+
+    beforeEach(function() {
+        module('openlmis-table-form');
+
+        inject(function($injector) {
+            this.$compile = $injector.get('$compile');
+            this.$rootScope = $injector.get('$rootScope');
+        });
+
+        this.compileMarkup = function(markup) {
+            var element = this.$compile(markup)(this.$scope);
+            angular.element('body').append(element);
+            this.$scope.$apply();
+            return element;
+        };
+
+        this.$scope = this.$rootScope.$new();
+
+        var markup =
+            '<table><tr><td>' +
+                '<textarea>short</textarea>' +
+            '</td></tr></table>';
+
+        this.html = this.compileMarkup(markup);
+        this.textarea = this.html.find('textarea');
+    });
+
+    it('should set an explicit width and height when textarea has a value', function() {
+        expect(parseInt(this.textarea[0].style.width, 10)).toBeGreaterThan(0);
+        expect(parseInt(this.textarea[0].style.height, 10)).toBeGreaterThan(0);
+    });
+
+    it('should grow width when value becomes longer', function() {
+        var previousWidth = parseInt(this.textarea[0].style.width, 10);
+
+        this.textarea[0].value = 'a value that is clearly longer than the initial one';
+        this.$scope.$apply();
+
+        expect(parseInt(this.textarea[0].style.width, 10)).toBeGreaterThan(previousWidth);
+    });
+
+    it('should grow height when value spans multiple lines', function() {
+        var previousHeight = parseInt(this.textarea[0].style.height, 10);
+
+        this.textarea[0].value = 'first line\nsecond line\nthird line\nfourth line';
+        this.$scope.$apply();
+
+        expect(parseInt(this.textarea[0].style.height, 10)).toBeGreaterThan(previousHeight);
+    });
+
+    it('should do nothing for a textarea outside of a table cell', function() {
+        var markup =
+            '<form>' +
+                '<textarea>outside</textarea>' +
+            '</form>';
+
+        var element = this.compileMarkup(markup);
+        var textarea = element.find('textarea');
+
+        expect(textarea[0].style.width).toEqual('');
+        expect(textarea[0].style.height).toEqual('');
+    });
+});


### PR DESCRIPTION
Editable text fields in table cells now widen with their content up to a limit, then wrap and grow taller.