### PR TITLE
OLMIS-8238: Add facility packs/doses toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Upcoming Version (WIP)
 ==================
 
 Improvements:
+* [OLMIS-8238](https://openlmis.atlassian.net/browse/OLMIS-8238): Add facility-level packs/doses display configuration.
 * [SELV3-748](https://openlmis.atlassian.net/browse/SELV3-748) Resolved cookie issue causing untranslated warning messages
 
 7.2.15 / 2026-02-05

--- a/src/openlmis-quantity-unit-toggle/quantity-unit-config.service.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit-config.service.js
@@ -1,0 +1,137 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc service
+     * @name openlmis-quantity-unit-toggle.quantityUnitConfigService
+     *
+     * @description
+     * Holds the current quantity unit display mode (PACKS, DOSES or BOTH). The mode defaults to the
+     * build-time ${QUANTITY_UNIT_OPTION} placeholder, but may be overridden at runtime (e.g. from the
+     * current user's home facility configuration) via setMode.
+     */
+    angular
+        .module('openlmis-quantity-unit-toggle')
+        .service('quantityUnitConfigService', service);
+
+    service.$inject = ['QUANTITY_UNIT', 'localStorageService'];
+
+    function service(QUANTITY_UNIT, localStorageService) {
+
+        var QUANTITY_UNIT_KEY = 'quantityUnit';
+        var VALID_MODES = [QUANTITY_UNIT.PACKS, QUANTITY_UNIT.DOSES, QUANTITY_UNIT.BOTH];
+        var VALID_UNITS = [QUANTITY_UNIT.PACKS, QUANTITY_UNIT.DOSES];
+
+        var defaultMode = toValid(VALID_MODES, '${QUANTITY_UNIT_OPTION}', QUANTITY_UNIT.BOTH);
+        var defaultUnit = toValid(VALID_UNITS, '${DEFAULT_QUANTITY_UNIT}', QUANTITY_UNIT.DOSES);
+        var mode = defaultMode;
+
+        this.getMode = getMode;
+        this.getEffectiveUnit = getEffectiveUnit;
+        this.setSelectedUnit = setSelectedUnit;
+        this.setMode = setMode;
+        this.resetMode = resetMode;
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-quantity-unit-toggle.quantityUnitConfigService
+         * @name getMode
+         *
+         * @description
+         * Returns the current display mode (PACKS, DOSES or BOTH).
+         */
+        function getMode() {
+            return mode;
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-quantity-unit-toggle.quantityUnitConfigService
+         * @name getEffectiveUnit
+         *
+         * @description
+         * Resolves the unit (PACKS or DOSES) that should currently be displayed. When the facility
+         * mode forces a single unit it is returned and any cached user choice is ignored; when the
+         * mode is BOTH the user's last choice from local storage is used, falling back to the
+         * default unit. This is the single source of truth for all consumers.
+         *
+         * @return {String}  PACKS or DOSES
+         */
+        function getEffectiveUnit() {
+            if (mode !== QUANTITY_UNIT.BOTH) {
+                return mode;
+            }
+
+            var cachedQuantityUnit = localStorageService.get(QUANTITY_UNIT_KEY);
+            return cachedQuantityUnit === null ? defaultUnit : cachedQuantityUnit;
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-quantity-unit-toggle.quantityUnitConfigService
+         * @name setSelectedUnit
+         *
+         * @description
+         * Persists the unit the user selected on the toggle so it becomes their default on the next
+         * page. Only meaningful while the mode is BOTH.
+         *
+         * @param {String} unit PACKS or DOSES
+         */
+        function setSelectedUnit(unit) {
+            if (VALID_UNITS.indexOf(unit) !== -1) {
+                localStorageService.add(QUANTITY_UNIT_KEY, unit);
+            }
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-quantity-unit-toggle.quantityUnitConfigService
+         * @name setMode
+         *
+         * @description
+         * Overrides the display mode. Invalid values are ignored so a misconfigured facility cannot
+         * break the toggle.
+         *
+         * @param {String} newMode one of PACKS, DOSES, BOTH
+         */
+        function setMode(newMode) {
+            if (VALID_MODES.indexOf(newMode) !== -1) {
+                mode = newMode;
+            }
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-quantity-unit-toggle.quantityUnitConfigService
+         * @name resetMode
+         *
+         * @description
+         * Resets the mode back to the build-time default. Called at the start of each post-login
+         * flow (and on logout) so a user without facility-level configuration does not inherit the
+         * previous user's facility mode.
+         */
+        function resetMode() {
+            mode = defaultMode;
+        }
+
+        function toValid(allowed, value, fallback) {
+            return allowed.indexOf(value) === -1 ? fallback : value;
+        }
+    }
+})();

--- a/src/openlmis-quantity-unit-toggle/quantity-unit-config.service.spec.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit-config.service.spec.js
@@ -1,0 +1,122 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('quantityUnitConfigService', function() {
+
+    beforeEach(function() {
+        module('openlmis-quantity-unit-toggle', function($provide) {
+            $provide.value('featureFlagService', {
+                set: function() {},
+                get: function() {}
+            });
+        });
+
+        inject(function($injector) {
+            this.quantityUnitConfigService = $injector.get('quantityUnitConfigService');
+            this.QUANTITY_UNIT = $injector.get('QUANTITY_UNIT');
+            this.localStorageService = $injector.get('localStorageService');
+        });
+    });
+
+    describe('getMode', function() {
+
+        it('should default to BOTH when no facility mode is set', function() {
+            expect(this.quantityUnitConfigService.getMode()).toEqual(this.QUANTITY_UNIT.BOTH);
+        });
+
+        it('should return mode set via setMode', function() {
+            this.quantityUnitConfigService.setMode(this.QUANTITY_UNIT.PACKS);
+
+            expect(this.quantityUnitConfigService.getMode()).toEqual(this.QUANTITY_UNIT.PACKS);
+        });
+
+        it('should ignore an invalid mode and keep the previous one', function() {
+            this.quantityUnitConfigService.setMode('NONSENSE');
+
+            expect(this.quantityUnitConfigService.getMode()).toEqual(this.QUANTITY_UNIT.BOTH);
+        });
+
+        it('should ignore an undefined mode and keep the previous one', function() {
+            this.quantityUnitConfigService.setMode(this.QUANTITY_UNIT.DOSES);
+            this.quantityUnitConfigService.setMode(undefined);
+
+            expect(this.quantityUnitConfigService.getMode()).toEqual(this.QUANTITY_UNIT.DOSES);
+        });
+    });
+
+    describe('resetMode', function() {
+
+        it('should reset the mode back to the build-time default', function() {
+            this.quantityUnitConfigService.setMode(this.QUANTITY_UNIT.PACKS);
+
+            this.quantityUnitConfigService.resetMode();
+
+            expect(this.quantityUnitConfigService.getMode()).toEqual(this.QUANTITY_UNIT.BOTH);
+        });
+    });
+
+    describe('getEffectiveUnit', function() {
+
+        it('should force PACKS and ignore storage when mode is PACKS', function() {
+            spyOn(this.localStorageService, 'get').andReturn(this.QUANTITY_UNIT.DOSES);
+            this.quantityUnitConfigService.setMode(this.QUANTITY_UNIT.PACKS);
+
+            expect(this.quantityUnitConfigService.getEffectiveUnit()).toEqual(this.QUANTITY_UNIT.PACKS);
+            expect(this.localStorageService.get).not.toHaveBeenCalled();
+        });
+
+        it('should force DOSES and ignore storage when mode is DOSES', function() {
+            spyOn(this.localStorageService, 'get').andReturn(this.QUANTITY_UNIT.PACKS);
+            this.quantityUnitConfigService.setMode(this.QUANTITY_UNIT.DOSES);
+
+            expect(this.quantityUnitConfigService.getEffectiveUnit()).toEqual(this.QUANTITY_UNIT.DOSES);
+            expect(this.localStorageService.get).not.toHaveBeenCalled();
+        });
+
+        it('should use the stored unit when mode is BOTH', function() {
+            spyOn(this.localStorageService, 'get').andReturn(this.QUANTITY_UNIT.PACKS);
+            this.quantityUnitConfigService.setMode(this.QUANTITY_UNIT.BOTH);
+
+            expect(this.quantityUnitConfigService.getEffectiveUnit()).toEqual(this.QUANTITY_UNIT.PACKS);
+            expect(this.localStorageService.get).toHaveBeenCalledWith('quantityUnit');
+        });
+
+        it('should fall back to the default unit when mode is BOTH and storage is empty', function() {
+            spyOn(this.localStorageService, 'get').andReturn(null);
+            this.quantityUnitConfigService.setMode(this.QUANTITY_UNIT.BOTH);
+
+            expect(this.quantityUnitConfigService.getEffectiveUnit()).toEqual(this.QUANTITY_UNIT.DOSES);
+        });
+    });
+
+    describe('setSelectedUnit', function() {
+
+        it('should store the chosen unit under the quantityUnit key', function() {
+            spyOn(this.localStorageService, 'add');
+
+            this.quantityUnitConfigService.setSelectedUnit(this.QUANTITY_UNIT.PACKS);
+
+            expect(this.localStorageService.add).toHaveBeenCalledWith('quantityUnit', this.QUANTITY_UNIT.PACKS);
+        });
+
+        it('should ignore an invalid unit and not store it', function() {
+            spyOn(this.localStorageService, 'add');
+
+            this.quantityUnitConfigService.setSelectedUnit('NONSENSE');
+
+            expect(this.localStorageService.add).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.controller.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.controller.js
@@ -29,12 +29,11 @@
         .controller('QuantityUnitToggleController', QuantityUnitToggleController);
 
     QuantityUnitToggleController.$inject = [
-        'messageService', 'QUANTITY_UNIT', 'localStorageService'
+        'messageService', 'QUANTITY_UNIT', 'quantityUnitConfigService', '$rootScope'
     ];
 
-    var QUANTITY_UNIT_KEY = 'quantityUnit';
-
-    function QuantityUnitToggleController(messageService, QUANTITY_UNIT, localStorageService) {
+    function QuantityUnitToggleController(messageService, QUANTITY_UNIT, quantityUnitConfigService,
+                                          $rootScope) {
 
         var vm = this;
 
@@ -79,12 +78,8 @@
                 QUANTITY_UNIT.PACKS,
                 QUANTITY_UNIT.DOSES
             ];
-            var cachedQuantityUnit = localStorageService.get(QUANTITY_UNIT_KEY);
-            if (cachedQuantityUnit === null) {
-                vm.quantityUnit = QUANTITY_UNIT.$getDefaultQuantityUnit();
-            } else {
-                vm.quantityUnit = cachedQuantityUnit;
-            }
+
+            vm.quantityUnit = quantityUnitConfigService.getEffectiveUnit();
         }
 
         /**
@@ -108,7 +103,8 @@
          * Handles change in toggle.
          */
         function onChange() {
-            localStorageService.add(QUANTITY_UNIT_KEY, vm.quantityUnit);
+            quantityUnitConfigService.setSelectedUnit(vm.quantityUnit);
+            $rootScope.$emit('openlmis.quantityUnit.selected', vm.quantityUnit);
         }
 
         /**
@@ -120,7 +116,7 @@
          * Returns information about quantity unit toggle visibility.
          */
         function isQuantityUnitToggleVisible() {
-            return '${QUANTITY_UNIT_OPTION}' === QUANTITY_UNIT.BOTH;
+            return quantityUnitConfigService.getMode() === QUANTITY_UNIT.BOTH;
         }
 
     }

--- a/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.controller.spec.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.controller.spec.js
@@ -15,7 +15,7 @@
 
 describe('QuantityUnitToggleController', function() {
 
-    var vm, $controller, messageService, QUANTITY_UNIT, localStorageService;
+    var vm, $controller, $rootScope, messageService, QUANTITY_UNIT, quantityUnitConfigService;
 
     beforeEach(function() {
         module('openlmis-quantity-unit-toggle', function($provide) {
@@ -27,14 +27,16 @@ describe('QuantityUnitToggleController', function() {
 
         inject(function($injector) {
             $controller = $injector.get('$controller');
+            $rootScope = $injector.get('$rootScope');
             messageService = $injector.get('messageService');
             QUANTITY_UNIT = $injector.get('QUANTITY_UNIT');
-            localStorageService = $injector.get('localStorageService');
+            quantityUnitConfigService = $injector.get('quantityUnitConfigService');
         });
 
         vm = $controller('QuantityUnitToggleController', {
             messageService: messageService,
-            localStorageService: localStorageService
+            quantityUnitConfigService: quantityUnitConfigService,
+            $rootScope: $rootScope
         });
     });
 
@@ -49,31 +51,33 @@ describe('QuantityUnitToggleController', function() {
             ]);
         });
 
-        it('should expose default quantityUnit when not cached in storage', function() {
-            spyOn(localStorageService, 'get').andReturn(null);
-            spyOn(QUANTITY_UNIT, '$getDefaultQuantityUnit').andReturn('DOSES');
-
-            vm.$onInit();
-
-            expect(vm.quantityUnit).toEqual(QUANTITY_UNIT.DOSES);
-            expect(QUANTITY_UNIT.$getDefaultQuantityUnit).toHaveBeenCalled();
-            expect(localStorageService.get).toHaveBeenCalledWith('quantityUnit');
-        });
-
-        it('should expose quantityUnit doses from storage', function() {
-            spyOn(localStorageService, 'get').andReturn('DOSES');
-
-            vm.$onInit();
-
-            expect(vm.quantityUnit).toEqual(QUANTITY_UNIT.DOSES);
-        });
-
-        it('should expose quantityUnit packs from storage', function() {
-            spyOn(localStorageService, 'get').andReturn('PACKS');
+        it('should set quantityUnit from the effective unit resolved by the config service', function() {
+            spyOn(quantityUnitConfigService, 'getEffectiveUnit').andReturn(QUANTITY_UNIT.PACKS);
 
             vm.$onInit();
 
             expect(vm.quantityUnit).toEqual(QUANTITY_UNIT.PACKS);
+        });
+    });
+
+    describe('isQuantityUnitToggleVisible', function() {
+
+        it('should be visible when mode is BOTH', function() {
+            spyOn(quantityUnitConfigService, 'getMode').andReturn(QUANTITY_UNIT.BOTH);
+
+            expect(vm.isQuantityUnitToggleVisible()).toBe(true);
+        });
+
+        it('should be hidden when mode is PACKS', function() {
+            spyOn(quantityUnitConfigService, 'getMode').andReturn(QUANTITY_UNIT.PACKS);
+
+            expect(vm.isQuantityUnitToggleVisible()).toBe(false);
+        });
+
+        it('should be hidden when mode is DOSES', function() {
+            spyOn(quantityUnitConfigService, 'getMode').andReturn(QUANTITY_UNIT.DOSES);
+
+            expect(vm.isQuantityUnitToggleVisible()).toBe(false);
         });
     });
 
@@ -98,24 +102,25 @@ describe('QuantityUnitToggleController', function() {
 
     describe('onChange', function() {
 
-        it('should add quantityUnit doses to local storage', function() {
-            spyOn(localStorageService, 'add');
+        it('should persist the selected unit through the config service', function() {
+            spyOn(quantityUnitConfigService, 'setSelectedUnit');
             vm.quantityUnit = QUANTITY_UNIT.DOSES;
 
             vm.onChange();
 
-            expect(localStorageService.add).toHaveBeenCalledWith('quantityUnit', QUANTITY_UNIT.DOSES);
+            expect(quantityUnitConfigService.setSelectedUnit).toHaveBeenCalledWith(QUANTITY_UNIT.DOSES);
         });
 
-        it('should add quantityUnit packs to local storage', function() {
-            spyOn(localStorageService, 'add');
+        it('should emit an event so the selection can be persisted per user', function() {
+            spyOn(quantityUnitConfigService, 'setSelectedUnit');
+            spyOn($rootScope, '$emit');
             vm.quantityUnit = QUANTITY_UNIT.PACKS;
 
             vm.onChange();
 
-            expect(localStorageService.add).toHaveBeenCalledWith('quantityUnit', QUANTITY_UNIT.PACKS);
+            expect($rootScope.$emit)
+                .toHaveBeenCalledWith('openlmis.quantityUnit.selected', QUANTITY_UNIT.PACKS);
         });
-
     });
 
 });

--- a/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.jsx
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit-toggle.jsx
@@ -4,12 +4,8 @@ import getService from '../react-components/utils/angular-utils';
 export default function QuantityUnitToggle({ selectedUnit, onUnitChange }) {
   const { formatMessage } = useMemo(() => getService('messageService'), []);
   const QUANTITY_UNIT = useMemo(() => getService('QUANTITY_UNIT'), []);
-  const featureFlagService = useMemo(
-    () => getService('featureFlagService'),
-    []
-  );
-  const QUANTITY_UNIT_OPTION_FEATURE_FLAG = useMemo(
-    () => getService('QUANTITY_UNIT_OPTION_FEATURE_FLAG'),
+  const quantityUnitConfigService = useMemo(
+    () => getService('quantityUnitConfigService'),
     []
   );
   const quantityUnits = useMemo(
@@ -17,20 +13,10 @@ export default function QuantityUnitToggle({ selectedUnit, onUnitChange }) {
     [QUANTITY_UNIT]
   );
 
-  const isVisible = useMemo(() => {
-    if (featureFlagService && QUANTITY_UNIT_OPTION_FEATURE_FLAG) {
-      const quantityUnitOption = featureFlagService.get(
-        QUANTITY_UNIT_OPTION_FEATURE_FLAG
-      );
-      return quantityUnitOption === QUANTITY_UNIT.BOTH;
-    }
-
-    return false;
-  }, [
-    featureFlagService,
-    QUANTITY_UNIT_OPTION_FEATURE_FLAG,
-    QUANTITY_UNIT.BOTH,
-  ]);
+  const isVisible = useMemo(
+    () => quantityUnitConfigService.getMode() === QUANTITY_UNIT.BOTH,
+    [quantityUnitConfigService, QUANTITY_UNIT.BOTH]
+  );
 
   const handleQuantityUnitChange = useCallback(
     (event) => {

--- a/src/openlmis-quantity-unit-toggle/quantity-unit.constant.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit.constant.js
@@ -33,8 +33,7 @@
             PACKS: 'PACKS',
             DOSES: 'DOSES',
             BOTH: 'BOTH',
-            $getDisplayName: getDisplayName,
-            $getDefaultQuantityUnit: getDefaultQuantityUnit
+            $getDisplayName: getDisplayName
         };
         var displayNames = {
             PACKS: 'openlmisQuantityUnitToggle.packs',
@@ -45,10 +44,6 @@
 
         function getDisplayName(name) {
             return displayNames[name];
-        }
-
-        function getDefaultQuantityUnit() {
-            return '${DEFAULT_QUANTITY_UNIT}';
         }
     }
 


### PR DESCRIPTION
Part of OLMIS-8238. Facility-level packs/doses mode and toggle (visible in BOTH mode); the toggle announces the user's selection so it can be persisted per user.

https://openlmis.atlassian.net/browse/OLMIS-8238