### PR TITLE
OLMIS-8177: Show required tooltip on invalid table inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.2.17-SNAPSHOT (WIP)
 ==================
 
+Bug fixes:
+* [OLMIS-8177](https://openlmis.atlassian.net/browse/OLMIS-8177): React table input cells (packs/doses quantity) now show a "This field is required" tooltip when invalid, instead of a tooltip-less red mark.
+
 7.2.16 / 2026-06-09
 ==================
 

--- a/src/react-components/table/input-cell.jsx
+++ b/src/react-components/table/input-cell.jsx
@@ -17,6 +17,9 @@ import React, { useState, useEffect } from 'react';
 
 import NumericInput from '../inputs/numeric-input';
 import Input from '../inputs/input';
+import WebTooltip from '../modals/web-tooltip';
+
+const FIELD_REQUIRED_TOOLTIP = 'This field is required';
 
 const InputCell = ({
     value: initialValue,
@@ -58,10 +61,12 @@ const InputCell = ({
     }, [showValidationErrors]);
 
     return (
-        <div className={`form-control ${valid ? '' : 'is-invalid'}`}>
-            {numeric && <NumericInput value={value} onChange={onChange} onBlur={onBlur} disabled={disabled} {...props} />}
-            {!numeric && <Input value={value} onChange={onChange} onBlur={onBlur} disabled={disabled} {...props} />}
-        </div>
+        <WebTooltip shouldDisplayTooltip={!valid} tooltipContent={FIELD_REQUIRED_TOOLTIP}>
+            <div className={`form-control ${valid ? '' : 'is-invalid'}`}>
+                {numeric && <NumericInput value={value} onChange={onChange} onBlur={onBlur} disabled={disabled} {...props} />}
+                {!numeric && <Input value={value} onChange={onChange} onBlur={onBlur} disabled={disabled} {...props} />}
+            </div>
+        </WebTooltip>
     );
 };
 


### PR DESCRIPTION
React table input cells now display a required-field tooltip when invalid, instead of a tooltip-less red mark.