### PR TITLE
OLMIS-8244: Add packs-to-order preview hint

### DIFF
--- a/src/openlmis-quantity-unit-input/_openlmis-quantity-unit-input.scss
+++ b/src/openlmis-quantity-unit-input/_openlmis-quantity-unit-input.scss
@@ -11,6 +11,14 @@
     width: 60px;
 }
 
+.packs-to-order-hint {
+    display: block;
+    margin-top: 4px;
+    font-size: 0.85em;
+    font-style: italic;
+    color: #666;
+}
+
 .openlmis-table > tbody > tr > td.has-single-input-control.is-invalid > openlmis-quantity-unit-input {
   @include icon("exclamation-circle");
 

--- a/src/openlmis-quantity-unit-input/messages_en.json
+++ b/src/openlmis-quantity-unit-input/messages_en.json
@@ -1,5 +1,6 @@
 {
     "openlmisInputDosesPacks.Doses": "Doses",
     "openlmisInputDosesPacks.Packs": "Packs",
-    "openlmisInputDosesPacks.DosesBracket":" doses )"
+    "openlmisInputDosesPacks.DosesBracket":" doses )",
+    "openlmisInputDosesPacks.willBeOrderedAsPacks": "Will be ordered as ${packs} pack(s) (${doses} doses)"
 }

--- a/src/openlmis-quantity-unit-input/openlmis-quantity-unit-input.jsx
+++ b/src/openlmis-quantity-unit-input/openlmis-quantity-unit-input.jsx
@@ -7,6 +7,7 @@ export default function QuantityUnitInput({
   showInDoses,
   item,
   onChangeQuantity,
+  showPacksToOrderHint,
   ...inputCellProps
 }) {
   const messageService = useMemo(() => getService('messageService'), []);
@@ -77,6 +78,44 @@ export default function QuantityUnitInput({
     [messageService]
   );
 
+  // Preview of the whole-pack quantity that a requisition-less order will ultimately be ordered as
+  // (the backend rounds doses -> packs at send). Only shown when the consumer opts in via
+  // showPacksToOrderHint and net content makes packs meaningful.
+  const packsToOrderHint = useMemo(() => {
+    if (!showPacksToOrderHint || netContent === 1) {
+      return null;
+    }
+
+    const totalDoses = showInDoses
+      ? Number(localValues.orderedQuantity)
+      : (Number(localValues.quantityInPacks) || 0) * netContent
+          + (Number(localValues.quantityRemainderInDoses) || 0);
+
+    if (!totalDoses || totalDoses <= 0) {
+      return null;
+    }
+
+    const packs = quantityUnitCalculateService.packsToOrder(
+      totalDoses,
+      netContent,
+      item?.orderable?.packRoundingThreshold,
+      item?.orderable?.roundToZero
+    );
+
+    return messageService.get('openlmisInputDosesPacks.willBeOrderedAsPacks', {
+      packs: packs,
+      doses: packs * netContent,
+    });
+  }, [
+    showPacksToOrderHint,
+    netContent,
+    showInDoses,
+    localValues,
+    quantityUnitCalculateService,
+    item,
+    messageService,
+  ]);
+
   useEffect(() => {
     // Recalculate the item if it has orderedQuantity but no quantityRemainderInDoses or quantityInPacks
     // and if we are not showing in doses
@@ -114,37 +153,45 @@ export default function QuantityUnitInput({
           onBlur={handleBlur}
           key={`orderedQuantity-${item?.orderable?.id}`}
         />
+        {packsToOrderHint && (
+          <p className='packs-to-order-hint'>{packsToOrderHint}</p>
+        )}
       </div>
     );
   }
 
   return (
-    <div className='openlmis-input'>
-      <InputCell
-        {...inputCellProps}
-        value={localValues.quantityInPacks}
-        onChange={(value) => handleLocalChange('quantityInPacks', value)}
-        onBlur={handleBlur}
-        placeholder={formatMessage('openlmisInputDosesPacks.Packs')}
-        id='quantityInPacks'
-        key={`quantityInPacks-${item?.orderable?.id}`}
-      />
-      <p> ( + </p>
-      <InputCell
-        {...inputCellProps}
-        value={localValues.quantityRemainderInDoses}
-        onChange={(value) =>
-          handleLocalChange('quantityRemainderInDoses', value)
-        }
-        onBlur={handleBlur}
-        disabled={
-          inputCellProps.disabled || isQuantityRemainderInDosesDisabled()
-        }
-        placeholder={formatMessage('openlmisInputDosesPacks.Doses')}
-        id='quantityRemainderInDoses'
-        key={`quantityRemainderInDoses-${item?.orderable?.id}`}
-      />
-      <p>{formatMessage('openlmisInputDosesPacks.DosesBracket')}</p>
+    <div>
+      <div className='openlmis-input'>
+        <InputCell
+          {...inputCellProps}
+          value={localValues.quantityInPacks}
+          onChange={(value) => handleLocalChange('quantityInPacks', value)}
+          onBlur={handleBlur}
+          placeholder={formatMessage('openlmisInputDosesPacks.Packs')}
+          id='quantityInPacks'
+          key={`quantityInPacks-${item?.orderable?.id}`}
+        />
+        <p> ( + </p>
+        <InputCell
+          {...inputCellProps}
+          value={localValues.quantityRemainderInDoses}
+          onChange={(value) =>
+            handleLocalChange('quantityRemainderInDoses', value)
+          }
+          onBlur={handleBlur}
+          disabled={
+            inputCellProps.disabled || isQuantityRemainderInDosesDisabled()
+          }
+          placeholder={formatMessage('openlmisInputDosesPacks.Doses')}
+          id='quantityRemainderInDoses'
+          key={`quantityRemainderInDoses-${item?.orderable?.id}`}
+        />
+        <p>{formatMessage('openlmisInputDosesPacks.DosesBracket')}</p>
+      </div>
+      {packsToOrderHint && (
+        <p className='packs-to-order-hint'>{packsToOrderHint}</p>
+      )}
     </div>
   );
 }

--- a/src/openlmis-quantity-unit-toggle/quantity-unit.service.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit.service.js
@@ -34,6 +34,7 @@
 
         this.recalculateSOHQuantity = recalculateSOHQuantity;
         this.recalculateInputQuantity = recalculateInputQuantity;
+        this.packsToOrder = packsToOrder;
 
         /**
          * @ngdoc method
@@ -134,6 +135,44 @@
             }
 
             return quantityInDoses;
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-quantity-unit-toggle.quantityUnitCalculateService
+         * @name packsToOrder
+         *
+         * @description
+         * Returns the number of whole packs that will be ordered for a given quantity in dispensing
+         * units (doses), applying the orderable's pack rounding configuration. JS port that mirrors
+         * the canonical referencedata Orderable#packsToOrder algorithm (also in fulfillment
+         * OrderableDto and requisition's BasicOrderableDto) - keep behaviourally identical so the UI
+         * preview matches what the backend stores on send.
+         *
+         * @param  {number}  quantity              the quantity in dispensing units (doses)
+         * @param  {number}  netContent            quantity of doses in one pack
+         * @param  {number}  packRoundingThreshold remainder above which a partial pack is rounded up
+         * @param  {boolean} roundToZero           whether a non-zero quantity may round down to 0 packs
+         * @return {number}                         the number of packs that will be ordered
+         */
+        function packsToOrder(quantity, netContent, packRoundingThreshold, roundToZero) {
+            if (!quantity || quantity <= 0 || isNetContentUndefinedOrZero(netContent)) {
+                return 0;
+            }
+
+            var threshold = packRoundingThreshold || 0;
+            var packs = Math.floor(quantity / netContent);
+            var remainder = quantity % netContent;
+
+            if (remainder > 0 && remainder > threshold) {
+                packs += 1;
+            }
+
+            if (packs === 0 && !roundToZero) {
+                packs = 1;
+            }
+
+            return packs;
         }
 
         function isNetContentUndefinedOrZero(netContent) {

--- a/src/openlmis-quantity-unit-toggle/quantity-unit.service.spec.js
+++ b/src/openlmis-quantity-unit-toggle/quantity-unit.service.spec.js
@@ -1,0 +1,67 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('quantityUnitCalculateService', function() {
+
+    var quantityUnitCalculateService;
+
+    beforeEach(function() {
+        module('openlmis-quantity-unit-toggle', function($provide) {
+            $provide.value('featureFlagService', {
+                set: function() {},
+                get: function() {}
+            });
+        });
+
+        inject(function($injector) {
+            quantityUnitCalculateService = $injector.get('quantityUnitCalculateService');
+        });
+    });
+
+    // These cases mirror the backend fulfillment OrderableDtoTest (and the canonical
+    // referencedata Orderable#packsToOrder) one-for-one, so the UI preview matches what the
+    // backend will store on send.
+    describe('packsToOrder', function() {
+
+        it('should return packs for an exact multiple', function() {
+            expect(quantityUnitCalculateService.packsToOrder(20, 10, 0, false)).toEqual(2);
+        });
+
+        it('should round up when remainder exceeds threshold', function() {
+            expect(quantityUnitCalculateService.packsToOrder(23, 10, 0, false)).toEqual(3);
+        });
+
+        it('should not round up when remainder is within threshold', function() {
+            expect(quantityUnitCalculateService.packsToOrder(23, 10, 5, false)).toEqual(2);
+        });
+
+        it('should round to one when result is zero and roundToZero is false', function() {
+            expect(quantityUnitCalculateService.packsToOrder(3, 10, 5, false)).toEqual(1);
+        });
+
+        it('should round to zero when result is zero and roundToZero is true', function() {
+            expect(quantityUnitCalculateService.packsToOrder(3, 10, 5, true)).toEqual(0);
+        });
+
+        it('should return zero for zero net content', function() {
+            expect(quantityUnitCalculateService.packsToOrder(10, 0, 0, false)).toEqual(0);
+        });
+
+        it('should return zero for non-positive quantity', function() {
+            expect(quantityUnitCalculateService.packsToOrder(0, 10, 0, false)).toEqual(0);
+            expect(quantityUnitCalculateService.packsToOrder(-5, 10, 0, false)).toEqual(0);
+        });
+    });
+});


### PR DESCRIPTION
## OLMIS-8244 — "Will be ordered as X pack(s)" preview hint

https://openlmis.atlassian.net/browse/OLMIS-8244

Companion to the backend fix [OpenLMIS/openlmis-fulfillment#55](https://github.com/OpenLMIS/openlmis-fulfillment/pull/55),
which converts requisition-less order quantities from doses to packs **at send**. Because the entered
doses are rounded to whole packs on send, the user should see the result beforehand.

### Change
`openlmis-quantity-unit-input` now renders a hint under the quantity input — e.g.
*"Will be ordered as 2 pack(s) (168 doses)"* — in both Doses and Packs input modes.

- `quantity-unit.service.js` — adds `packsToOrder(quantity, netContent, packRoundingThreshold,
  roundToZero)`, a JS port behaviourally identical to the backend `OrderableDto.packsToOrder` /
  canonical referencedata `Orderable#packsToOrder`, so the preview matches what the backend stores.
- `openlmis-quantity-unit-input.jsx` — `showPacksToOrderHint` prop + memoised hint; hidden when
  `netContent === 1` (nothing to round) or quantity is empty/zero.
- New message key `openlmisInputDosesPacks.willBeOrderedAsPacks` and a small style for the hint.

### Tests
- `quantity-unit.service.spec.js` (new) — 7 cases mirroring the backend `OrderableDtoTest`
  one-for-one (exact, round-up, round-down within threshold, sub-pack min-1, roundToZero, zero net
  content, non-positive quantity).

### E2E verified (live)
Hint correct across exact (252→3), round-up (130→2), round-down (100→1, 200→2, 90→1), sub-pack
min-1 (20→1); Packs mode (2 packs + 50 doses → 3); hidden for netContent=1 (Male Condom) and for
quantity 0/empty.
